### PR TITLE
fix: permissions in version-bump

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -10,6 +10,9 @@ jobs:
   bump-version:
     name: Bump and Tag Version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - uses: jefflinse/pr-semver-bump@v1.6.0


### PR DESCRIPTION
Fix permissions so that the bump can actually set the new tag